### PR TITLE
Add pantry and ML suggestion tables

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 from api.v1.users import router as users_router
 from api.v1.recipes import router as recipes_router
 from api.v1.ingredients import router as ingredients_router
+from models import user_ingredient, recipe_suggestion  # ensure tables are created
 from db.base import Base
 from db.session import engine
 

--- a/models/recipe.py
+++ b/models/recipe.py
@@ -15,3 +15,6 @@ class Recipe(Base):
     ingredients = relationship(
         "Ingredient", back_populates="recipe", cascade="all, delete-orphan"
     )
+    suggestions = relationship(
+        "RecipeSuggestion", back_populates="recipe", cascade="all, delete-orphan"
+    )

--- a/models/recipe_suggestion.py
+++ b/models/recipe_suggestion.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, Float, ForeignKey
+from sqlalchemy.orm import relationship
+
+from db.base import Base
+
+
+class RecipeSuggestion(Base):
+    __tablename__ = "recipe_suggestions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    recipe_id = Column(Integer, ForeignKey("recipes.id"), nullable=False)
+    score = Column(Float, nullable=True)
+
+    user = relationship("User", back_populates="suggestions")
+    recipe = relationship("Recipe")

--- a/models/user.py
+++ b/models/user.py
@@ -11,3 +11,9 @@ class User(Base):
     name = Column(String, nullable=False)
 
     recipes = relationship("Recipe", back_populates="owner")
+    pantry = relationship(
+        "UserIngredient", back_populates="user", cascade="all, delete-orphan"
+    )
+    suggestions = relationship(
+        "RecipeSuggestion", back_populates="user", cascade="all, delete-orphan"
+    )

--- a/models/user_ingredient.py
+++ b/models/user_ingredient.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+
+from db.base import Base
+
+
+class UserIngredient(Base):
+    __tablename__ = "user_ingredients"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    ingredient_id = Column(Integer, ForeignKey("ingredients.id"), nullable=False)
+    quantity = Column(String, nullable=True)
+
+    user = relationship("User", back_populates="pantry")
+    ingredient = relationship("Ingredient")

--- a/schemas/ingredient.py
+++ b/schemas/ingredient.py
@@ -4,6 +4,10 @@ from pydantic import BaseModel
 class IngredientBase(BaseModel):
     name: str
     quantity: Optional[str] = None
+    calories: Optional[float] = None
+    proteins: Optional[float] = None
+    carbs: Optional[float] = None
+    fats: Optional[float] = None
 
 class IngredientCreate(IngredientBase):
     pass

--- a/schemas/recipe_suggestion.py
+++ b/schemas/recipe_suggestion.py
@@ -1,0 +1,19 @@
+from typing import Optional
+from pydantic import BaseModel
+
+
+class RecipeSuggestionBase(BaseModel):
+    user_id: int
+    recipe_id: int
+    score: Optional[float] = None
+
+
+class RecipeSuggestionCreate(RecipeSuggestionBase):
+    pass
+
+
+class RecipeSuggestion(RecipeSuggestionBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/schemas/user_ingredient.py
+++ b/schemas/user_ingredient.py
@@ -1,0 +1,19 @@
+from typing import Optional
+from pydantic import BaseModel
+
+
+class UserIngredientBase(BaseModel):
+    user_id: int
+    ingredient_id: int
+    quantity: Optional[str] = None
+
+
+class UserIngredientCreate(UserIngredientBase):
+    pass
+
+
+class UserIngredient(UserIngredientBase):
+    id: int
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- include nutrition info on ingredient schema
- add models for user pantry (`user_ingredients`) and ML recommendations (`recipe_suggestions`)
- expose new relationships in existing models
- import new models on startup so tables are created

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68582a4fe824832689056c4735344c2b