### PR TITLE
Implement recipe suggestions

### DIFF
--- a/api/v1/recipes.py
+++ b/api/v1/recipes.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from api.deps import get_db
+from ml.recommender import suggest_recipes
 from models.ingredient import Ingredient as IngredientModel
 from models.recipe import Recipe as RecipeModel
 from schemas.recipe import Recipe, RecipeCreate
@@ -25,6 +26,12 @@ def create_recipe(recipe: RecipeCreate, db: Session = Depends(get_db)):
     db.commit()
     db.refresh(db_recipe)
     return db_recipe
+
+
+@router.get("/suggested", response_model=List[Recipe])
+def suggested_recipes(user_id: int, db: Session = Depends(get_db)):
+    """Return recipes recommended for the given user."""
+    return suggest_recipes(user_id, db)
 
 
 @router.get("/{recipe_id}", response_model=Recipe)

--- a/ml/recommender.py
+++ b/ml/recommender.py
@@ -1,3 +1,39 @@
-"""Placeholder for recipe recommendation logic."""
+"""Simple ingredient based recipe recommendation engine."""
 
-# TODO: implement machine learning based recommender system
+from typing import List
+
+from sqlalchemy.orm import Session
+
+from models.user import User
+from models.recipe import Recipe
+
+
+def _recipe_score(recipe: Recipe, pantry_ids: set[int]) -> float:
+    """Return the percentage of a recipe's ingredients present in the pantry."""
+    if not recipe.ingredients:
+        return 0.0
+    recipe_ids = {ing.id for ing in recipe.ingredients}
+    if not recipe_ids:
+        return 0.0
+    return len(recipe_ids & pantry_ids) / len(recipe_ids)
+
+
+def suggest_recipes(user_id: int, db: Session, limit: int = 5) -> List[Recipe]:
+    """Return recipes sorted by ingredient overlap with the user's pantry."""
+
+    user: User | None = db.query(User).get(user_id)
+    if user is None:
+        return []
+
+    pantry_ids = {item.ingredient_id for item in user.pantry}
+    if not pantry_ids:
+        return []
+
+    recipes = db.query(Recipe).all()
+    scored = [
+        (recipe, _recipe_score(recipe, pantry_ids))
+        for recipe in recipes
+    ]
+    scored.sort(key=lambda x: x[1], reverse=True)
+
+    return [recipe for recipe, score in scored if score > 0][:limit]

--- a/tests/test_recommender.py
+++ b/tests/test_recommender.py
@@ -1,0 +1,63 @@
+import unittest
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from db.base import Base
+from models.user import User
+from models.ingredient import Ingredient
+from models.recipe import Recipe
+from models.user_ingredient import UserIngredient
+
+from ml.recommender import suggest_recipes
+
+
+class RecommenderTestCase(unittest.TestCase):
+    def setUp(self):
+        engine = create_engine(
+            "sqlite:///:memory:", connect_args={"check_same_thread": False}
+        )
+        TestingSessionLocal = sessionmaker(bind=engine)
+        Base.metadata.create_all(engine)
+        self.db = TestingSessionLocal()
+
+        self.user = User(email="test@example.com", name="Test User")
+        self.db.add(self.user)
+        self.db.commit()
+        self.db.refresh(self.user)
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_suggest_recipes_basic(self):
+        ing1 = Ingredient(name="Apple")
+        ing2 = Ingredient(name="Banana")
+        ing3 = Ingredient(name="Carrot")
+        self.db.add_all([ing1, ing2, ing3])
+        self.db.commit()
+
+        ui1 = UserIngredient(
+            user_id=self.user.id, ingredient_id=ing1.id, quantity_grams=100
+        )
+        ui2 = UserIngredient(
+            user_id=self.user.id, ingredient_id=ing2.id, quantity_grams=50
+        )
+        self.db.add_all([ui1, ui2])
+        self.db.commit()
+
+        r1 = Recipe(title="Fruit Salad", description="Delicious")
+        r1.ingredients.append(ing1)
+        r2 = Recipe(title="Carrot Soup", description="Yummy")
+        r2.ingredients.append(ing3)
+        self.db.add_all([r1, r2])
+        self.db.commit()
+
+        suggestions = suggest_recipes(self.user.id, self.db)
+
+        self.assertEqual(len(suggestions), 1)
+        self.assertEqual(suggestions[0].title, "Fruit Salad")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add ingredient overlap recommendation engine
- expose `/api/v1/recipes/suggested` endpoint
- unit test for recommender

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install sqlalchemy` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6858319bf4608326a4db5f74c3362e58