### PR TITLE
Fix SQLAlchemy mapping for RecipeSuggestion

### DIFF
--- a/models/recipe.py
+++ b/models/recipe.py
@@ -3,6 +3,9 @@ from sqlalchemy.orm import relationship
 
 from db.base import Base
 
+# Import model referenced in relationships so SQLAlchemy registers it
+from .recipe_suggestion import RecipeSuggestion  # noqa: F401
+
 class Recipe(Base):
     __tablename__ = "recipes"
 

--- a/models/user.py
+++ b/models/user.py
@@ -3,6 +3,9 @@ from sqlalchemy.orm import relationship
 
 from db.base import Base
 
+# Import models referenced in relationships so SQLAlchemy can resolve them
+from .recipe_suggestion import RecipeSuggestion  # noqa: F401
+
 class User(Base):
     __tablename__ = "users"
 


### PR DESCRIPTION
## Summary
- ensure `RecipeSuggestion` model is imported when `User` or `Recipe` models are loaded so SQLAlchemy registers all mappings
- keep tests green

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685832f3d5c083268fe9dd7058ac8a07