### PR TITLE
Link Vite frontend to FastAPI

### DIFF
--- a/frontend/src/pages/CreateRecipe.jsx
+++ b/frontend/src/pages/CreateRecipe.jsx
@@ -1,4 +1,43 @@
-function CreateRecipe() {
-    return <h2>Create a Recipe</h2>
+import { useState } from "react";
+import api from "../api";
+
+export default function CreateRecipe() {
+    const [title, setTitle] = useState("");
+    const [description, setDescription] = useState("");
+    const [message, setMessage] = useState("");
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        try {
+            await api.post("/recipes", { title, description, ingredients: [] });
+            setMessage("Recette créée");
+            setTitle("");
+            setDescription("");
+        } catch (err) {
+            setMessage(err.response?.data?.detail || err.message);
+        }
+    };
+
+    return (
+        <div>
+            <h2>Créer une recette</h2>
+            <form onSubmit={handleSubmit}>
+                <input
+                    type="text"
+                    placeholder="Titre"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    required
+                />
+                <input
+                    type="text"
+                    placeholder="Description"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                />
+                <button type="submit">Envoyer</button>
+            </form>
+            <p>{message}</p>
+        </div>
+    );
 }
-export default CreateRecipe

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -11,6 +11,7 @@ export default function Login() {
         e.preventDefault();
         try {
             const res = await api.post("/users", { email, name });
+            localStorage.setItem("userId", res.data.id);
             setMessage("Utilisateur créé : " + res.data.name);
         } catch (err) {
             setMessage("Erreur : " + err.response?.data?.detail || err.message);

--- a/frontend/src/pages/Pantry.jsx
+++ b/frontend/src/pages/Pantry.jsx
@@ -1,4 +1,34 @@
-function Pantry() {
-    return <h2>My Pantry</h2>
+import { useEffect, useState } from "react";
+import api from "../api";
+
+export default function Pantry() {
+    const [items, setItems] = useState([]);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        const userId = localStorage.getItem("userId");
+        if (!userId) {
+            setError("Utilisateur non connecté");
+            return;
+        }
+        api.get(`/users/${userId}/pantry`)
+            .then((res) => setItems(res.data))
+            .catch((err) =>
+                setError(err.response?.data?.detail || err.message)
+            );
+    }, []);
+
+    return (
+        <div>
+            <h2>Mon garde-manger</h2>
+            {error && <p>{error}</p>}
+            <ul>
+                {items.map((it) => (
+                    <li key={it.ingredient_id}>
+                        {it.ingredient_id} : {it.quantity_grams}g
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
 }
-export default Pantry

--- a/frontend/src/pages/RecipesList.jsx
+++ b/frontend/src/pages/RecipesList.jsx
@@ -1,4 +1,27 @@
-function RecipesList() {
-    return <h2>Recipes List</h2>
+import { useEffect, useState } from "react";
+import api from "../api";
+
+export default function RecipesList() {
+    const [recipes, setRecipes] = useState([]);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        api.get("/recipes")
+            .then((res) => setRecipes(res.data))
+            .catch((err) =>
+                setError(err.response?.data?.detail || err.message)
+            );
+    }, []);
+
+    return (
+        <div>
+            <h2>Recipes List</h2>
+            {error && <p>{error}</p>}
+            <ul>
+                {recipes.map((r) => (
+                    <li key={r.id}>{r.title}</li>
+                ))}
+            </ul>
+        </div>
+    );
 }
-export default RecipesList

--- a/frontend/src/pages/Suggestions.jsx
+++ b/frontend/src/pages/Suggestions.jsx
@@ -1,4 +1,32 @@
-function Suggestions() {
-    return <h2>Suggestions</h2>
+import { useEffect, useState } from "react";
+import api from "../api";
+
+export default function Suggestions() {
+    const [recipes, setRecipes] = useState([]);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        const userId = localStorage.getItem("userId");
+        if (!userId) {
+            setError("Utilisateur non connecté");
+            return;
+        }
+        api.get("/recipes/suggested", { params: { user_id: userId } })
+            .then((res) => setRecipes(res.data))
+            .catch((err) =>
+                setError(err.response?.data?.detail || err.message)
+            );
+    }, []);
+
+    return (
+        <div>
+            <h2>Suggestions</h2>
+            {error && <p>{error}</p>}
+            <ul>
+                {recipes.map((r) => (
+                    <li key={r.id}>{r.title}</li>
+                ))}
+            </ul>
+        </div>
+    );
 }
-export default Suggestions


### PR DESCRIPTION
## Summary
- call FastAPI endpoints from React pages
- save user id after creating a user
- list recipes from the API
- create recipes from the form
- show pantry items and recipe suggestions

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858656ba3cc832691784d70a1d40db2