### PR TITLE
Implement recipe pages and fix schema

### DIFF
--- a/frontend/src/pages/CreateRecipe.jsx
+++ b/frontend/src/pages/CreateRecipe.jsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import api from "../api";
 
 export default function CreateRecipe() {
     const [title, setTitle] = useState("");
     const [description, setDescription] = useState("");
     const [message, setMessage] = useState("");
+    const navigate = useNavigate();
 
     const handleSubmit = async (e) => {
         e.preventDefault();
@@ -13,6 +15,7 @@ export default function CreateRecipe() {
             setMessage("Recette créée");
             setTitle("");
             setDescription("");
+            navigate("/recipes");
         } catch (err) {
             setMessage(err.response?.data?.detail || err.message);
         }

--- a/frontend/src/pages/RecipesList.jsx
+++ b/frontend/src/pages/RecipesList.jsx
@@ -5,18 +5,23 @@ export default function RecipesList() {
     const [recipes, setRecipes] = useState([]);
     const [error, setError] = useState("");
 
-    useEffect(() => {
+    const fetchRecipes = () => {
         api.get("/recipes")
             .then((res) => setRecipes(res.data))
             .catch((err) =>
                 setError(err.response?.data?.detail || err.message)
             );
+    };
+
+    useEffect(() => {
+        fetchRecipes();
     }, []);
 
     return (
         <div>
             <h2>Recipes List</h2>
             {error && <p>{error}</p>}
+            <button onClick={fetchRecipes}>Refresh</button>
             <ul>
                 {recipes.map((r) => (
                     <li key={r.id}>{r.title}</li>

--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ from db.session import engine
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Healthy Recipe API")
-app.include_router(api_router, prefix="/api/v1")
 
 
 app.include_router(users_router, prefix="/api/v1/users", tags=["Users"])

--- a/schemas/recipe.py
+++ b/schemas/recipe.py
@@ -1,28 +1,31 @@
+"""Pydantic models for recipe endpoints."""
+
 from typing import List, Optional
+
 from pydantic import BaseModel
+
 from .ingredient import Ingredient, IngredientCreate
 
+
 class RecipeBase(BaseModel):
+    """Common attributes shared by recipe schemas."""
+
     title: str
     description: Optional[str] = None
 
+
 class RecipeCreate(RecipeBase):
+    """Schema for creating a new recipe."""
+
     ingredients: List[IngredientCreate] = []
 
+
 class Recipe(RecipeBase):
+    """Schema returned from the API."""
+
     id: int
     owner_id: Optional[int] = None
     ingredients: List[Ingredient] = []
 
     class Config:
         from_attributes = True
-
-class RecipeBase(BaseModel):
-    title: str
-    description: str
-    ingredients: List[IngredientBase]
-
-class IngredientBase(BaseModel):
-    name: str
-    quantity: str
-    nutrition: Optional[NutritionData] = None


### PR DESCRIPTION
## Summary
- fix recipe schema definitions
- remove undefined `api_router` from FastAPI setup
- navigate to recipes list after recipe creation
- allow refreshing recipe list from UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685866ba6e608326a1e06dd1a78f42f7