### PR TITLE
Fix search_ingredient and add test endpoint

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -1,6 +1,9 @@
 """Application configuration settings."""
 
-from pydantic_settings import BaseSettings
+try:  # pragma: no cover - optional dependency
+    from pydantic_settings import BaseSettings
+except Exception:  # pragma: no cover - fallback when package missing
+    from pydantic import BaseSettings
 
 class Settings(BaseSettings):
     """Base configuration for the project."""

--- a/main.py
+++ b/main.py
@@ -26,3 +26,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.get("/test")
+def read_test():
+    """Simple health check endpoint used in tests."""
+    return {"message": "API opérationnelle", "status": "OK"}

--- a/utils/nutrition.py
+++ b/utils/nutrition.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 from typing import Dict
 
-from api.v1 import products
 
 try:  # pragma: no cover - optional dependency
     import requests
@@ -49,23 +48,7 @@ def search_ingredient(name: str, timeout: int = 10) -> Dict:
     except Exception as exc:  # pragma: no cover - network failures
         raise RuntimeError(f"Failed to fetch nutrition data: {exc}")
 
-    product = products[0]
-    result = {
-        "name": product.get("product_name", name),
-        "brand": product.get("brands"),
-        "categories": product.get("categories"),
-        "image_url": product.get("image_url"),
-        "nutriments": {
-            "energy": product["nutriments"].get("energy-kcal_100g"),
-            "fat": product["nutriments"].get("fat_100g"),
-            "saturated_fat": product["nutriments"].get("saturated-fat_100g"),
-            "carbohydrates": product["nutriments"].get("carbohydrates_100g"),
-            "sugars": product["nutriments"].get("sugars_100g"),
-            "fiber": product["nutriments"].get("fiber_100g"),
-            "proteins": product["nutriments"].get("proteins_100g"),
-            "salt": product["nutriments"].get("salt_100g"),
-        }
-    }
+    products = data.get("products", [])
     if not products:
         print("⚠️ Aucun produit trouvé pour :", name)
         return {}


### PR DESCRIPTION
## Summary
- update `search_ingredient` to use API results directly
- save nutriment data and warn when no product found
- fallback to `pydantic.BaseSettings` when `pydantic_settings` is missing
- add `/test` endpoint for health check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68639f572ce483269c296cd061041bd5